### PR TITLE
Extend application session lifespan 

### DIFF
--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -52,7 +53,8 @@ namespace InspiredCooking
 
             services.AddSession(options =>
             {
-                options.IdleTimeout = TimeSpan.FromSeconds(10);
+                // We want to keep the user session active for as long as possible
+                options.IdleTimeout = Timeout.InfiniteTimeSpan;
                 options.Cookie.HttpOnly = true;
                 options.Cookie.IsEssential = true;
             });

--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -59,16 +59,6 @@ namespace InspiredCooking
                 options.Cookie.IsEssential = true;
             });
 
-            // Remove character requirements from passwords
-            // See: https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity-configuration?view=aspnetcore-5.0#password
-            services.Configure<IdentityOptions>(options =>
-            {
-                options.Password.RequireDigit = false;
-                options.Password.RequireLowercase = false;
-                options.Password.RequireNonAlphanumeric = false;
-                options.Password.RequireUppercase = false;
-            });
-
             // for aspnetcore3.0+
             services.AddControllers();
         }

--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -58,6 +58,7 @@ namespace InspiredCooking
             });
 
             // Remove character requirements from passwords
+            // See: https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity-configuration?view=aspnetcore-5.0#password
             services.Configure<IdentityOptions>(options =>
             {
                 options.Password.RequireDigit = false;

--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -57,6 +57,15 @@ namespace InspiredCooking
                 options.Cookie.IsEssential = true;
             });
 
+            // Remove character requirements from passwords
+            services.Configure<IdentityOptions>(options =>
+            {
+                options.Password.RequireDigit = false;
+                options.Password.RequireLowercase = false;
+                options.Password.RequireNonAlphanumeric = false;
+                options.Password.RequireUppercase = false;
+            });
+
             // for aspnetcore3.0+
             services.AddControllers();
         }


### PR DESCRIPTION
Application was configured to clean sessions after 10 seconds of inactivity.
That was the reason menus were erased and we were getting consistently logged out.

Hope this Fixes #32 