### PR TITLE
Fix session IdleTimeout

### DIFF
--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -54,7 +53,7 @@ namespace InspiredCooking
             services.AddSession(options =>
             {
                 // We want to keep the user session active for as long as possible
-                options.IdleTimeout = Timeout.InfiniteTimeSpan;
+                options.IdleTimeout = TimeSpan.MaxValue;
                 options.Cookie.HttpOnly = true;
                 options.Cookie.IsEssential = true;
             });


### PR DESCRIPTION
Turns out that `Timeout.InfiniteTimeSpan` only works for threads (It's a negative number).

Switching over to the [struct MaxValue](https://docs.microsoft.com/en-us/dotnet/api/system.timespan.maxvalue?view=net-5.0)